### PR TITLE
fix: readme - yarn command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install --global @7i7o/git-remote-proland
 ### Using `yarn`
 
 ```bash
-yarn add --global @7i7o/git-remote-proland
+yarn global add @7i7o/git-remote-proland
 ```
 
 ### Using `pnpm`


### PR DESCRIPTION
## What has been done

- Fixed `yarn` command in `README`. Current command results in:
   ```
   error Missing list of packages to add to your project.
   info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
   ```

## How to test

- Run the command: `yarn global add @7i7o/git-remote-proland`
- Confirm it adds the command and is usable via `git`