### PR TITLE
Fix dirty cache after failed arweave upload or warp tx

### DIFF
--- a/.changeset/real-ghosts-brake.md
+++ b/.changeset/real-ghosts-brake.md
@@ -1,0 +1,5 @@
+---
+'@7i7o/git-remote-proland': patch
+---
+
+Fix dirty cache after failed upload to arweave

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -3,7 +3,6 @@ import type { Repo, Tag } from '../types';
 import { execSync } from 'child_process';
 import { accessSync, constants, readFileSync } from 'fs';
 import type { JsonWebKey } from 'crypto';
-import { emitKeypressEvents } from 'readline';
 import path from 'path';
 
 const ANSI_RESET = '\x1b[0m';

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -1,12 +1,17 @@
 import { getAddress } from './arweaveHelper';
 import type { Repo, Tag } from '../types';
 import { execSync } from 'child_process';
-import { readFileSync } from 'fs';
+import { accessSync, constants, readFileSync } from 'fs';
 import type { JsonWebKey } from 'crypto';
+import { emitKeypressEvents } from 'readline';
+import path from 'path';
 
 const ANSI_RESET = '\x1b[0m';
 const ANSI_RED = '\x1b[31m';
 const ANSI_GREEN = '\x1b[32m';
+
+const DIRTY_EXT = ".tmp"
+
 export const PL_TMP_PATH = '.protocol.land';
 export const GIT_CONFIG_KEYFILE = 'protocol.land.keyfile';
 export const getWarpContractTxId = () =>
@@ -119,6 +124,44 @@ export async function getTags(title: string, description: string) {
         { name: 'Description', value: description },
         { name: 'Type', value: 'repo-update' },
     ] as Tag[];
+}
+
+export function clearCache(
+    cachePath: string,
+    options: { keepFolders: string[] }
+) {
+    const { keepFolders = [] } = options;
+    const ommitedFolders = keepFolders.map((v) => `! -name "${v}"`).join(' ');
+    execSync(
+        `find ${cachePath} -mindepth 1 -maxdepth 1 -type d ${ommitedFolders} -exec rm -rf {} \\;`
+    );
+}
+
+export function setCacheDirty(cachePath: string, remoteName: string) {
+    if (!cachePath || !remoteName)
+        throw new Error('Cache and MutexName are required');
+    execSync(`touch ${path.join(cachePath, remoteName, DIRTY_EXT)}`);
+}
+
+export function unsetCacheDirty(cachePath: string, remoteName: string) {
+    if (!cachePath || !remoteName)
+        throw new Error('Cache and MutexName are required');
+    execSync(`rm -f ${path.join(cachePath, remoteName, DIRTY_EXT)}`);
+}
+
+export function isCacheDirty(cachePath: string, remoteName: string) {
+    if (!cachePath || !remoteName)
+        throw new Error('Cache and MutexName are required');
+    // Check if the file exists
+    try {
+        accessSync(
+            path.join(cachePath, remoteName, DIRTY_EXT),
+            constants.R_OK | constants.W_OK
+        );
+        return true;
+    } catch {
+        return false;
+    }
 }
 
 export const waitFor = (delay: number) =>

--- a/src/lib/protocolLandSync.ts
+++ b/src/lib/protocolLandSync.ts
@@ -6,7 +6,7 @@ import type { Repo } from '../types';
 import path from 'path';
 import { defaultCacheOptions } from 'warp-contracts/mjs';
 import { existsSync } from 'fs';
-import { PL_TMP_PATH, getTags, log } from './common';
+import { PL_TMP_PATH, clearCache, getTags, isCacheDirty, log } from './common';
 
 export const downloadProtocolLandRepo = async (
     repoId: string,
@@ -34,10 +34,17 @@ export const downloadProtocolLandRepo = async (
     // use tmp folder named as repo's latest dataTxId
     const latestVersionRepoPath = path.join(destPath, repo.dataTxId);
 
-    // if folder exsits, assume it's cached and return
+    // if folder exists, there is a cached remote
     if (existsSync(latestVersionRepoPath)) {
-        log(`Using cached repo in '${latestVersionRepoPath}'`);
-        return repo;
+        // check if cache is dirty
+        if (!isCacheDirty(destPath, repo.dataTxId)) {
+            // cache is clean, use it
+            log(`Using cached repo in '${latestVersionRepoPath}'`);
+            return repo;
+        }
+
+        // cache is dirty, clear cache and continue
+        clearCache(destPath, { keepFolders: ['cache'] });
     }
 
     // if not, download repo data from arweave
@@ -89,9 +96,7 @@ export const downloadProtocolLandRepo = async (
 
     // rm -rf everything but the bare repo and warp cache (discard stdout)
     try {
-        execSync(
-            `find ${destPath} -mindepth 1 -maxdepth 1 -type d ! -name "cache" ! -name "${repo.dataTxId}" -exec rm -rf {} \\;`
-        );
+        clearCache(destPath, { keepFolders: ['cache', repo.dataTxId] });
     } catch {}
 
     return repo;

--- a/src/lib/protocolLandSync.ts
+++ b/src/lib/protocolLandSync.ts
@@ -1,10 +1,9 @@
 import { getRepo, updateWarpRepo } from './warpHelper';
-import { execSync, spawn } from 'child_process';
+import { spawn } from 'child_process';
 import { arweaveDownload, uploadRepo } from './arweaveHelper';
 import { unpackGitRepo, zipRepoJsZip } from './zipHelper';
 import type { Repo } from '../types';
 import path from 'path';
-import { defaultCacheOptions } from 'warp-contracts/mjs';
 import { existsSync } from 'fs';
 import { PL_TMP_PATH, clearCache, getTags, isCacheDirty, log } from './common';
 

--- a/src/lib/remoteHelper.ts
+++ b/src/lib/remoteHelper.ts
@@ -17,7 +17,6 @@ import {
     setCacheDirty,
     unsetCacheDirty,
     waitFor,
-    walletNotFoundMessage,
 } from './common';
 
 // string to check if objects were pushed

--- a/src/lib/warpHelper.ts
+++ b/src/lib/warpHelper.ts
@@ -4,7 +4,7 @@ import {
     defaultCacheOptions,
     type LogLevel,
 } from 'warp-contracts/mjs';
-import { getWallet, getWarpContractTxId, log, waitFor } from './common';
+import { getWallet, getWarpContractTxId, waitFor } from './common';
 import type { Repo } from '../types';
 import path from 'path';
 


### PR DESCRIPTION
Cached git remote remained in an inconsistent state after upload to arweave failed or after a failed update to warp

This PR fixes it by cleaning the cached remotes after an unsuccessful push to protocol.land

# How to test
- Clone the repo
- Build
- create a symlink to `dist/index.js` with the name `proland-test` and add that to your PATH
- use `proland-test://[repo-id]` as remote to clone git command (remember to set up your wallet path in the git config)
- verify that the folder that caches the arweave txId inside `.git/.protocol.land/` exists after `git pull` or `git clone`
- try to push a big file from a wallet with no funds to ensure arweave upload fails and check the new messages
- verify that the folder that caches the arweave txId inside `.git/.protocol.land/` is removed