### PR TITLE
fix: Enhance .gitignore handling using 'git ls-files'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,11 @@
 #!/usr/bin/env node
 
+import { gitdir } from './lib/common';
 import { remoteHelper } from './lib/remoteHelper';
 
 // parse command line arguments
 const [remoteName, remoteUrl] = process.argv.slice(2, 4); // only use 2 parametes (remoteName and repo url)
 
-// get gitdir (usually '.git')
-const gitdir = process.env.GIT_DIR as string;
 if (!gitdir) throw new Error('Missing GIT_DIR env');
 
 remoteHelper({

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -15,14 +15,15 @@ export const PL_TMP_PATH = '.protocol.land';
 export const GIT_CONFIG_KEYFILE = 'protocol.land.keyfile';
 export const getWarpContractTxId = () =>
     'w5ZU15Y2cLzZlu3jewauIlnzbKw-OAxbN9G5TbuuiDQ';
+// get gitdir (usually '.git')
+export const gitdir = process.env.GIT_DIR as string;
 
 export const log = (message: any, options?: { color: 'red' | 'green' }) => {
     if (!options) console.error(` [PL] ${message}`);
     else {
         const { color } = options;
         console.error(
-            `${
-                color === 'red' ? ANSI_RED : ANSI_GREEN
+            `${color === 'red' ? ANSI_RED : ANSI_GREEN
             } [PL] ${message}${ANSI_RESET}`
         );
     }

--- a/src/lib/protocolLandSync.ts
+++ b/src/lib/protocolLandSync.ts
@@ -5,7 +5,14 @@ import { unpackGitRepo, zipRepoJsZip } from './zipHelper';
 import type { Repo } from '../types';
 import path from 'path';
 import { existsSync } from 'fs';
-import { PL_TMP_PATH, clearCache, getTags, isCacheDirty, log } from './common';
+import {
+    PL_TMP_PATH,
+    clearCache,
+    getTags,
+    gitdir,
+    isCacheDirty,
+    log,
+} from './common';
 
 export const downloadProtocolLandRepo = async (
     repoId: string,
@@ -106,22 +113,22 @@ export const uploadProtocolLandRepo = async (
     repo: Repo,
     destPath: string
 ) => {
-    // pack repo
-    log('Packing repo ...');
-    const buffer = await zipRepoJsZip(repo.name, repoPath, '', true, [
-        PL_TMP_PATH,
-    ]);
-
-    // upload to bundlr/arweave
-    log('Uploading to Arweave ...');
     let dataTxId: string | undefined;
     try {
+        // pack repo
+        log('Packing repo ...');
+        const buffer = await zipRepoJsZip(repo.name, repoPath, '', [
+            path.join(gitdir, PL_TMP_PATH),
+        ]);
+
+        // upload to bundlr/arweave
+        log('Uploading to Arweave ...');
         dataTxId = await uploadRepo(
             buffer,
             await getTags(repo.name, repo.description)
         );
-    } catch (error) {
-        log(error);
+    } catch (error: any) {
+        log(error?.message || error, { color: 'red' });
     }
     if (!dataTxId) return false;
 


### PR DESCRIPTION
## Summary
- Use `git ls-files` to get the files to upload ignoring files from .gitignore