### PR TITLE
fix: Support repository's new zip folder structure & private repo

### DIFF
--- a/.changeset/seven-jokes-beam.md
+++ b/.changeset/seven-jokes-beam.md
@@ -2,4 +2,4 @@
 '@protocol.land/git-remote-helper': patch
 ---
 
-Support repository's new zip folder structure
+Support repository's new zip folder structure & private repo

--- a/.changeset/seven-jokes-beam.md
+++ b/.changeset/seven-jokes-beam.md
@@ -1,0 +1,5 @@
+---
+'@protocol.land/git-remote-helper': patch
+---
+
+Support repository's new zip folder structure

--- a/src/lib/arweaveHelper.ts
+++ b/src/lib/arweaveHelper.ts
@@ -11,6 +11,14 @@ export async function getAddress(wallet?: JsonWebKey) {
     );
 }
 
+export function getActivePublicKey() {
+    const wallet = getWallet();
+    if (!wallet) {
+        process.exit(0);
+    }
+    return wallet.n;
+}
+
 export async function uploadRepo(zipBuffer: Buffer, tags: Tag[]) {
     try {
         // upload compressed repo using turbo

--- a/src/lib/privateRepo.ts
+++ b/src/lib/privateRepo.ts
@@ -1,0 +1,148 @@
+import Arweave from 'arweave';
+import crypto from 'crypto';
+import type { PrivateState } from '../types';
+import { getActivePublicKey } from './arweaveHelper';
+import { getWallet } from './common';
+
+const arweave = new Arweave({
+    host: 'ar-io.net',
+    port: 443,
+    protocol: 'https',
+});
+
+async function deriveAddress(publicKey: string) {
+    const pubKeyBuf = arweave.utils.b64UrlToBuffer(publicKey);
+    const sha512DigestBuf = await crypto.subtle.digest('SHA-512', pubKeyBuf);
+
+    return arweave.utils.bufferTob64Url(new Uint8Array(sha512DigestBuf));
+}
+
+async function encryptDataWithExistingKey(
+    file: ArrayBuffer,
+    aesKey: any,
+    iv: Uint8Array
+) {
+    let key = aesKey;
+
+    if (!(aesKey instanceof crypto.webcrypto.CryptoKey)) {
+        key = await crypto.subtle.importKey(
+            'raw',
+            aesKey,
+            { name: 'AES-GCM', length: 256 },
+            true,
+            ['encrypt']
+        );
+    }
+
+    const encrypted = await crypto.subtle.encrypt(
+        { name: 'AES-GCM', iv: iv },
+        key,
+        file
+    );
+
+    return encrypted;
+}
+
+async function decryptAesKeyWithPrivateKey(encryptedAesKey: Uint8Array) {
+    const privateKey = getWallet();
+    const key = await crypto.subtle.importKey(
+        'jwk',
+        privateKey,
+        {
+            name: 'RSA-OAEP',
+            hash: 'SHA-256',
+        },
+        false,
+        ['decrypt']
+    );
+
+    const options = {
+        name: 'RSA-OAEP',
+        hash: 'SHA-256',
+    };
+
+    const decryptedAesKey = await crypto.subtle.decrypt(
+        options,
+        key,
+        encryptedAesKey
+    );
+
+    return new Uint8Array(decryptedAesKey);
+}
+
+async function decryptFileWithAesGcm(
+    encryptedFile: ArrayBuffer,
+    decryptedAesKey: ArrayBuffer,
+    iv: Uint8Array
+) {
+    const aesKey = await crypto.subtle.importKey(
+        'raw',
+        decryptedAesKey,
+        { name: 'AES-GCM', length: 256 },
+        true,
+        ['decrypt']
+    );
+
+    const decryptedFile = await crypto.subtle.decrypt(
+        { name: 'AES-GCM', iv: iv },
+        aesKey,
+        encryptedFile
+    );
+
+    return decryptedFile;
+}
+
+export async function decryptRepo(
+    repoArrayBuf: ArrayBuffer,
+    privateStateTxId: string
+): Promise<ArrayBuffer> {
+    const response = await fetch(`https://arweave.net/${privateStateTxId}`);
+    const privateState = (await response.json()) as PrivateState;
+
+    const ivArrBuff = arweave.utils.b64UrlToBuffer(privateState.iv);
+
+    //public key -> hash -> get the aes key from object
+    const pubKey = getActivePublicKey();
+    const address = await deriveAddress(pubKey);
+
+    const encAesKeyStr = privateState.encKeys[address]!;
+    const encAesKeyBuf = arweave.utils.b64UrlToBuffer(encAesKeyStr);
+
+    const aesKey = (await decryptAesKeyWithPrivateKey(
+        encAesKeyBuf
+    )) as unknown as ArrayBuffer;
+    const decryptedRepo = await decryptFileWithAesGcm(
+        repoArrayBuf,
+        aesKey,
+        ivArrBuff
+    );
+
+    return decryptedRepo;
+}
+
+export async function encryptRepo(
+    repoArrayBuf: ArrayBuffer,
+    privateStateTxId: string
+) {
+    const pubKey = getActivePublicKey();
+    const address = await deriveAddress(pubKey);
+
+    const response = await fetch(`https://arweave.net/${privateStateTxId}`);
+    const privateState = (await response.json()) as PrivateState;
+
+    const encAesKeyStr = privateState.encKeys[address]!;
+    const encAesKeyBuf = arweave.utils.b64UrlToBuffer(encAesKeyStr);
+
+    const aesKey = (await decryptAesKeyWithPrivateKey(
+        encAesKeyBuf
+    )) as unknown as ArrayBuffer;
+    const ivArrBuff = arweave.utils.b64UrlToBuffer(privateState.iv);
+
+    const encryptedRepo = await encryptDataWithExistingKey(
+        repoArrayBuf,
+        aesKey,
+        ivArrBuff
+    );
+
+    return Buffer.from(encryptedRepo);
+}

--- a/src/lib/protocolLandSync.ts
+++ b/src/lib/protocolLandSync.ts
@@ -4,7 +4,7 @@ import { arweaveDownload, uploadRepo } from './arweaveHelper';
 import { unpackGitRepo, zipRepoJsZip } from './zipHelper';
 import type { Repo } from '../types';
 import path from 'path';
-import { existsSync } from 'fs';
+import { existsSync, promises as fsPromises } from 'fs';
 import {
     PL_TMP_PATH,
     clearCache,
@@ -79,9 +79,17 @@ export const downloadProtocolLandRepo = async (
         process.exit(0);
     }
 
-    // unpacked into `repo.name` folder, clone a bare repo from it
-    const unpackedRepoPath = path.join(destPath, repo.name);
+    // unpacked into `repo.id` folder, clone a bare repo from it
+    const unpackedRepoPath = path.join(destPath, repo.id);
     const bareRepoPath = path.join(destPath, repo.dataTxId);
+
+    // Rename parent id to repo id on cloning when fork has not been updated yet
+    if (repo.fork && repo.parent) {
+        const unpackedPath = path.join(destPath, repo.parent);
+        if (existsSync(unpackedPath)) {
+            await fsPromises.rename(unpackedPath, unpackedRepoPath);
+        }
+    }
 
     // clone it as a bare repo
     const cloned = await runCommand(
@@ -117,7 +125,7 @@ export const uploadProtocolLandRepo = async (
     try {
         // pack repo
         log('Packing repo ...');
-        const buffer = await zipRepoJsZip(repo.name, repoPath, '', [
+        const buffer = await zipRepoJsZip(repo.id, repoPath, '', [
             path.join(gitdir, PL_TMP_PATH),
         ]);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,13 @@ export type Repo = {
     privateStateTxId?: string;
 };
 
+export type PrivateState = {
+    iv: string;
+    encKeys: Record<string, string>;
+    version: string;
+    pubKeys: string[];
+};
+
 export type Tag = {
     name: string;
     value: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,10 @@ export type Repo = {
     dataTxId: string;
     owner: string;
     contributors: string[];
+    fork: boolean;
+    parent: string | null;
+    private: boolean;
+    privateStateTxId?: string;
 };
 
 export type Tag = {


### PR DESCRIPTION
## Summary

This PR addresses the recent update in the Protocol Land (PL) repository.

- Add support for modified zip folder structure. The previous zip format contained a `/repo-name` directory, while the updated version now contains a `/repo-id` directory. 

- It also adds support for private repo.

Related issues: [labscommunity/protocol-land#40](https://github.com/labscommunity/protocol-land/pull/40) https://github.com/labscommunity/protocol-land/pull/39