### PR TITLE
feat: Add push consent & display fees

### DIFF
--- a/.changeset/warm-clouds-dance.md
+++ b/.changeset/warm-clouds-dance.md
@@ -1,0 +1,5 @@
+---
+'@protocol.land/git-remote-helper': minor
+---
+
+feat: Add push consent with threshold configuration & display fees

--- a/README.md
+++ b/README.md
@@ -40,7 +40,34 @@ To enable `git push` or gain write access to repositories, you'll need an Arweav
 git config --global --add protocol.land.keyfile ~/private_folder/jwk_keyfile.json
 ```
 
-> **Note:** This globally adds the keyfile path for all repositories. If you prefer to use them selectively per repository, omit the `--global` modifier in the `git config` command.
+> [!Note]
+> This globally adds the keyfile path for all repositories. If you prefer to use them selectively per repository, omit the `--global` modifier in the `git config` command.
+
+## Setup Threshold Cost for Push consent
+
+> [!Note]
+> This functionality is compatible with UNIX-based operating systems such as Linux, macOS etc. For Windows users, leveraging the Windows Subsystem for Linux (WSL) is recommended.
+
+To effectively manage push consent based on the cost of pushing changes, you can configure a Threshold Cost. Use the `git config` command to set this threshold value:
+
+```bash
+git config --global --add protocol.land.thresholdCost 0.0003
+```
+
+This command sets the global threshold cost for push consent to `0.0003 AR`. When the estimated push cost exceeds this threshold, users will be prompted to consent to the fee before proceeding with the push.
+
+> [!Note]
+> This threshold is set globally for all repositories. If you wish to apply different thresholds for specific repositories, use the command without the `--global` modifier within the repository's directory.
+
+### Understanding Push Consent Logic
+
+Here's how it decides when to ask for your consent before uploading:
+
+- **No Set Threshold**: Without the threshold set, you'll only be asked for consent if the upload size exceeds the free subsidy size (For example: Turbo bundler used here allows upto 500KB uploads for free).
+- **Over the Threshold**: If the upload cost is more than the threshold, consent is requested only if the upload size is larger than what's freely allowed.
+- **Under the Threshold**: For costs below the threshold, consent isn't needed, and uploads proceed automatically.
+
+Adjusting the threshold cost allows users and organizations to maintain control over their expenditure on network fees, ensuring transparency and consent for every push operation that incurs a cost above the specified threshold.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     },
     "scripts": {
         "lint": "tsc",
-        "build": "tsup src/index.ts --format esm --dts",
+        "build": "tsup src/index.ts --format esm",
         "release": "pnpm run build && changeset publish"
     },
     "keywords": [
@@ -26,9 +26,7 @@
     },
     "files": [
         "dist/",
-        "src/",
         "package.json",
-        "tsconfig.json",
         "LICENSE",
         "README.md"
     ],

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
         "arweave": "^1.14.4",
         "jszip": "^3.10.1",
         "node-machine-id": "^1.1.12",
+        "redstone-api": "^0.4.11",
         "uuid": "^9.0.1",
-        "warp-contracts": "^1.4.19"
+        "warp-contracts": "^1.4.25"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,11 +20,14 @@ dependencies:
   node-machine-id:
     specifier: ^1.1.12
     version: 1.1.12
+  redstone-api:
+    specifier: ^0.4.11
+    version: 0.4.11
   uuid:
     specifier: ^9.0.1
     version: 9.0.1
   warp-contracts:
-    specifier: ^1.4.19
+    specifier: ^1.4.25
     version: 1.4.25
 
 devDependencies:
@@ -1057,6 +1060,14 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /ar-gql@0.0.6:
+    resolution: {integrity: sha512-eXKsXGQcx8uwxwlFJzBXA17Qsg+Gty6tcp85IB5SX1iop7NsXLQ/iH2WEz69NCz2/Zcb81C1QryIiNTgw0/4aA==}
+    dependencies:
+      axios: 0.21.4
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /arbundles@0.10.0(arweave@1.14.4):
     resolution: {integrity: sha512-Prbkjb0RSR6ToXPaBFhsBiMYSq78vHWbG/Zzy1tALRGvnKYlNLq93cqtmCNHqaYP6YCBZZV05ZpbO5C6269saw==}
     dependencies:
@@ -1183,6 +1194,15 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /arweave-multihost@0.1.0:
+    resolution: {integrity: sha512-biIkzQ3oc4RLV1MORQnqWz51IazP++K/8SsYMjUokK0cUfBLqom4pufKFCjTkGQIZMWWanXxnZqL66hHPgTCgA==}
+    dependencies:
+      arweave: 1.14.4
+      axios: 0.21.4
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /arweave-stream-tx@1.2.2(arweave@1.14.4):
     resolution: {integrity: sha512-bNt9rj0hbAEzoUZEF2s6WJbIz8nasZlZpxIw03Xm8fzb9gRiiZlZGW3lxQLjfc9Z0VRUWDzwtqoYeEoB/JDToQ==}
     requiresBuild: true
@@ -1247,6 +1267,14 @@ packages:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
     dev: true
+
+  /axios@0.21.4:
+    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
+    dependencies:
+      follow-redirects: 1.15.3
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /axios@1.6.2:
     resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
@@ -1644,6 +1672,12 @@ packages:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /deep-sort-object@1.0.2:
+    resolution: {integrity: sha512-Ko2XVMhRhz5Mxyb+QhLX13SHgcK1vuxc6XEfOyTMlbRbv7bhSmMqUw4ywqRwKgV25W+FDIaZjPWQrdblHCTwdA==}
+    dependencies:
+      is-plain-object: 2.0.4
+    dev: false
 
   /defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
@@ -2323,6 +2357,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /is-plain-object@2.0.4:
+    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      isobject: 3.0.1
+    dev: false
+
   /is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
@@ -2392,6 +2433,11 @@ packages:
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
+
+  /isobject@3.0.1:
+    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -2578,6 +2624,10 @@ packages:
 
   /lodash.union@4.6.0:
     resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}
+    dev: false
+
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: false
 
   /lru-cache@4.1.5:
@@ -2878,6 +2928,10 @@ packages:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
     dev: false
 
+  /pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+    dev: false
+
   /parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
@@ -3060,6 +3114,20 @@ packages:
       indent-string: 4.0.0
       strip-indent: 3.0.0
     dev: true
+
+  /redstone-api@0.4.11:
+    resolution: {integrity: sha512-X0gj7UU5aLQPmNjdnhBUCvi6tkj5SpQJ7heT6+TIPx7Od707n4oqKHoJa41V8QOGjudbxaM1BIv6+2+hp0wFGQ==}
+    dependencies:
+      ar-gql: 0.0.6
+      arweave: 1.14.4
+      arweave-multihost: 0.1.0
+      axios: 0.21.4
+      deep-sort-object: 1.0.2
+      lodash: 4.17.21
+      pako: 2.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /regenerator-runtime@0.14.0:
     resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -70,7 +70,6 @@ export const trackRepositoryUpdateEvent = async (
     wallet: any,
     data: Record<any, any>
 ) => {
-    return;
     await trackAmplitudeAnalyticsEvent(
         'Repository',
         'Add files to repo',
@@ -84,7 +83,6 @@ export const trackRepositoryCloneEvent = async (
     wallet: any,
     data: Record<any, any>
 ) => {
-    return;
     await trackAmplitudeAnalyticsEvent(
         'Repository',
         'Clone a repo',

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -70,6 +70,7 @@ export const trackRepositoryUpdateEvent = async (
     wallet: any,
     data: Record<any, any>
 ) => {
+    return;
     await trackAmplitudeAnalyticsEvent(
         'Repository',
         'Add files to repo',
@@ -83,6 +84,7 @@ export const trackRepositoryCloneEvent = async (
     wallet: any,
     data: Record<any, any>
 ) => {
+    return;
     await trackAmplitudeAnalyticsEvent(
         'Repository',
         'Clone a repo',

--- a/src/lib/arweaveHelper.ts
+++ b/src/lib/arweaveHelper.ts
@@ -1,6 +1,5 @@
-import Arweave from 'arweave';
 import { ArweaveSigner, createData } from 'arbundles';
-import { getWallet, log } from './common';
+import { getWallet, initArweave, log } from './common';
 import type { Tag } from '../types';
 import { withAsync } from './withAsync';
 import type { JsonWebKey } from 'crypto';
@@ -33,14 +32,6 @@ export async function uploadRepo(zipBuffer: Buffer, tags: Tag[]) {
         log(`Posted Tx to Arweave: ${arweaveTxId}`);
         return arweaveTxId;
     }
-}
-
-function initArweave() {
-    return Arweave.init({
-        host: 'arweave.net',
-        port: 443,
-        protocol: 'https',
-    });
 }
 
 export async function arweaveDownload(txId: string) {

--- a/src/lib/arweaveHelper.ts
+++ b/src/lib/arweaveHelper.ts
@@ -1,5 +1,7 @@
 import { ArweaveSigner, createData } from 'arbundles';
-import { getWallet, initArweave, log } from './common';
+import readline from 'node:readline';
+import fs, { promises as fsPromises } from 'fs';
+import { getThresholdCost, getWallet, initArweave, log } from './common';
 import type { Tag } from '../types';
 import { withAsync } from './withAsync';
 import type { JsonWebKey } from 'crypto';
@@ -18,19 +20,119 @@ export function getActivePublicKey() {
     return wallet.n;
 }
 
-export async function uploadRepo(zipBuffer: Buffer, tags: Tag[]) {
+async function checkAccessToTty() {
     try {
-        // upload compressed repo using turbo
-        const turboTxId = await turboUpload(zipBuffer, tags);
-        log(`Posted Tx to Turbo: ${turboTxId}`);
-        return turboTxId;
+        await fsPromises.access(
+            '/dev/tty',
+            fs.constants.F_OK | fs.constants.R_OK | fs.constants.W_OK
+        );
+        return true;
+    } catch (err) {
+        return false;
+    }
+}
+
+function createTtyReadlineInterface() {
+    const ttyReadStream = fs.createReadStream('/dev/tty');
+    const ttyWriteStream = fs.createWriteStream('/dev/tty');
+
+    const rl = readline.createInterface({
+        input: ttyReadStream,
+        output: ttyWriteStream,
+    });
+
+    return {
+        rl,
+        ttyReadStream,
+        ttyWriteStream,
+    };
+}
+
+function askQuestionThroughTty(question: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const { rl, ttyReadStream, ttyWriteStream } =
+            createTtyReadlineInterface();
+
+        rl.question(question, (answer: string) => {
+            rl.close();
+            ttyReadStream.destroy();
+            ttyWriteStream.end();
+            ttyWriteStream.on('finish', () => {
+                resolve(answer.trim().toLowerCase());
+            });
+        });
+
+        rl.on('error', (err) => reject(err));
+        ttyReadStream.on('error', (err) => reject(err));
+        ttyWriteStream.on('error', (err) => reject(err));
+    });
+}
+
+const shouldPushChanges = async (
+    uploadSize: number,
+    uploadCost: number,
+    subsidySize: number
+) => {
+    let hasAccessToTty = await checkAccessToTty();
+
+    // If no access to TTY, proceed with push by default.
+    if (!hasAccessToTty) return true;
+
+    const thresholdCost = getThresholdCost();
+
+    let showPushConsent;
+
+    if (thresholdCost === null) {
+        // No threshold: Show consent only if above strategy's subsidy.
+        showPushConsent = uploadSize > subsidySize;
+    } else if (uploadCost > thresholdCost) {
+        // Above Threshold: Show consent only if above strategy's subsidy.
+        showPushConsent = uploadSize > subsidySize;
+    } else {
+        // Below Threshold: Don't show consent.
+        showPushConsent = false;
+    }
+
+    // If no consent needed, proceed with push.
+    if (!showPushConsent) return true;
+
+    // Ask for user consent through TTY.
+    try {
+        const answer = await askQuestionThroughTty(' [PL] Push? (y/n): ');
+        return answer === 'yes' || answer === 'y';
+    } catch (err) {
+        return true;
+    }
+};
+
+export async function uploadRepo(
+    zipBuffer: Buffer,
+    tags: Tag[],
+    uploadSize: number,
+    uploadCost: number
+) {
+    async function attemptUpload(
+        subsidySize: number,
+        uploaderName: string,
+        uploader: (buffer: Buffer, tags: Tag[]) => Promise<string>
+    ) {
+        const pushChanges = await shouldPushChanges(
+            uploadSize,
+            uploadCost,
+            subsidySize
+        );
+        if (pushChanges) {
+            const txId = await uploader(zipBuffer, tags);
+            log(`Posted Tx to ${uploaderName}: ${txId}`);
+            return txId;
+        }
+    }
+
+    try {
+        const subsidySize = 500 * 1024; // 500KB;
+        return await attemptUpload(subsidySize, 'Turbo', turboUpload);
     } catch (error) {
-        // dismiss error and try with arweave
-        log('Turbo failed, trying with Arweave...');
-        // let Arweave throw if it encounters errors
-        const arweaveTxId = await arweaveUpload(zipBuffer, tags);
-        log(`Posted Tx to Arweave: ${arweaveTxId}`);
-        return arweaveTxId;
+        return await attemptUpload(0, 'Arweave', arweaveUpload);
     }
 }
 

--- a/src/lib/arweaveHelper.ts
+++ b/src/lib/arweaveHelper.ts
@@ -124,8 +124,9 @@ export async function uploadRepo(
         if (pushChanges) {
             const txId = await uploader(zipBuffer, tags);
             log(`Posted Tx to ${uploaderName}: ${txId}`);
-            return txId;
+            return { txId, pushCancelled: false };
         }
+        return { txid: '', pushCancelled: true };
     }
 
     try {

--- a/src/lib/arweaveHelper.ts
+++ b/src/lib/arweaveHelper.ts
@@ -132,6 +132,7 @@ export async function uploadRepo(
         const subsidySize = 500 * 1024; // 500KB;
         return await attemptUpload(subsidySize, 'Turbo', turboUpload);
     } catch (error) {
+        log('Turbo failed, trying with Arweave...');
         return await attemptUpload(0, 'Arweave', arweaveUpload);
     }
 }

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -14,6 +14,7 @@ const DIRTY_EXT = '.tmp';
 
 export const PL_TMP_PATH = '.protocol.land';
 export const GIT_CONFIG_KEYFILE = 'protocol.land.keyfile';
+export const GIT_CONFIG_THRESHOLD_COST = 'protocol.land.thresholdCost';
 export const getWarpContractTxId = () =>
     'xw8kD7s33ElIEioN96sPmLTJj9Rs2v4dZ67KWWKqojQ';
 // get gitdir (usually '.git')
@@ -48,6 +49,20 @@ export const getJwkPath = () => {
             .trim();
     } catch (error) {
         return '';
+    }
+};
+
+export const getThresholdCost = () => {
+    try {
+        const threshold = execSync(
+            `git config --get ${GIT_CONFIG_THRESHOLD_COST}`
+        )
+            .toString()
+            .trim();
+        if (threshold === '') return null;
+        return +threshold;
+    } catch (error) {
+        return null;
     }
 };
 

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -16,7 +16,7 @@ export const PL_TMP_PATH = '.protocol.land';
 export const GIT_CONFIG_KEYFILE = 'protocol.land.keyfile';
 export const GIT_CONFIG_THRESHOLD_COST = 'protocol.land.thresholdCost';
 export const getWarpContractTxId = () =>
-    'xw8kD7s33ElIEioN96sPmLTJj9Rs2v4dZ67KWWKqojQ';
+    'w5ZU15Y2cLzZlu3jewauIlnzbKw-OAxbN9G5TbuuiDQ';
 // get gitdir (usually '.git')
 export const gitdir = process.env.GIT_DIR as string;
 

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -4,6 +4,7 @@ import { execSync } from 'child_process';
 import { accessSync, constants, readFileSync } from 'fs';
 import type { JsonWebKey } from 'crypto';
 import path from 'path';
+import Arweave from 'arweave';
 
 const ANSI_RESET = '\x1b[0m';
 const ANSI_RED = '\x1b[31m';
@@ -14,16 +15,25 @@ const DIRTY_EXT = '.tmp';
 export const PL_TMP_PATH = '.protocol.land';
 export const GIT_CONFIG_KEYFILE = 'protocol.land.keyfile';
 export const getWarpContractTxId = () =>
-    'w5ZU15Y2cLzZlu3jewauIlnzbKw-OAxbN9G5TbuuiDQ';
+    'xw8kD7s33ElIEioN96sPmLTJj9Rs2v4dZ67KWWKqojQ';
 // get gitdir (usually '.git')
 export const gitdir = process.env.GIT_DIR as string;
+
+export function initArweave() {
+    return Arweave.init({
+        host: 'arweave.net',
+        port: 443,
+        protocol: 'https',
+    });
+}
 
 export const log = (message: any, options?: { color: 'red' | 'green' }) => {
     if (!options) console.error(` [PL] ${message}`);
     else {
         const { color } = options;
         console.error(
-            `${color === 'red' ? ANSI_RED : ANSI_GREEN
+            `${
+                color === 'red' ? ANSI_RED : ANSI_GREEN
             } [PL] ${message}${ANSI_RESET}`
         );
     }

--- a/src/lib/prices.ts
+++ b/src/lib/prices.ts
@@ -62,7 +62,9 @@ export async function calculateEstimate(bytes: number) {
 
     return {
         formattedSize,
-        costInAR: costInAR.toPrecision(5),
-        costInUSD: costInUSD.toPrecision(5),
+        costInAR: costInAR,
+        costInARWithPrecision: costInAR.toPrecision(5),
+        costInUSD: costInUSD,
+        costInUSDWithPrecision: costInUSD.toPrecision(5),
     };
 }

--- a/src/lib/prices.ts
+++ b/src/lib/prices.ts
@@ -1,0 +1,68 @@
+import redstone from 'redstone-api';
+import { initArweave } from './common';
+
+interface CoinGeckoPriceResult {
+    arweave: {
+        [key: string]: number;
+    };
+    [key: string]: {
+        [key: string]: number;
+    };
+}
+
+export async function getArPrice() {
+    try {
+        const data = (await (
+            await fetch(
+                `https://api.coingecko.com/api/v3/simple/price?ids=arweave&vs_currencies=usd`
+            )
+        ).json()) as CoinGeckoPriceResult;
+
+        return data.arweave.usd as number;
+    } catch (e) {
+        const response = await redstone.getPrice('AR');
+
+        if (!response.value) {
+            return 0;
+        }
+
+        return (response.source as any).coingecko as number;
+    }
+}
+
+export async function getWinstonPriceForBytes(bytes: number) {
+    try {
+        const response = await fetch(`https://arweave.net/price/${bytes}`);
+        const winston = await response.text();
+
+        return +winston;
+    } catch (error: any) {
+        throw new Error(error);
+    }
+}
+
+export function formatBytes(bytes: number): string {
+    if (bytes === 0) return '0 Bytes';
+
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+    const k = 1024;
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+}
+
+export async function calculateEstimate(bytes: number) {
+    const formattedSize = formatBytes(bytes);
+
+    const costInWinston = await getWinstonPriceForBytes(bytes);
+    const costInAR = +initArweave().ar.winstonToAr(costInWinston.toString());
+
+    const costFor1ARInUSD = await getArPrice();
+    const costInUSD = costInAR * costFor1ARInUSD;
+
+    return {
+        formattedSize,
+        costInAR: costInAR.toPrecision(5),
+        costInUSD: costInUSD.toPrecision(5),
+    };
+}

--- a/src/lib/privateRepo.ts
+++ b/src/lib/privateRepo.ts
@@ -1,14 +1,9 @@
-import Arweave from 'arweave';
 import crypto from 'crypto';
 import type { PrivateState } from '../types';
 import { getActivePublicKey } from './arweaveHelper';
-import { getWallet } from './common';
+import { getWallet, initArweave } from './common';
 
-const arweave = new Arweave({
-    host: 'ar-io.net',
-    port: 443,
-    protocol: 'https',
-});
+const arweave = initArweave();
 
 async function deriveAddress(publicKey: string) {
     const pubKeyBuf = arweave.utils.b64UrlToBuffer(publicKey);

--- a/src/lib/remoteHelper.ts
+++ b/src/lib/remoteHelper.ts
@@ -198,7 +198,7 @@ const spawnPipedGitCommand = async (
 
             waitFor(1000);
 
-            const success = await uploadProtocolLandRepo(
+            const { success, pushCancelled } = await uploadProtocolLandRepo(
                 pathToPack,
                 repo,
                 tmpPath
@@ -211,6 +211,16 @@ const spawnPipedGitCommand = async (
 
             // remove inconsistent cache mark
             unsetCacheDirty(tmpPath, repo.dataTxId);
+
+            if (pushCancelled) {
+                log(
+                    `Pushing repo '${repo.id}' to Protocol Land was cancelled`,
+                    {
+                        color: 'red',
+                    }
+                );
+                process.exit(0);
+            }
 
             if (success) {
                 log(`Successfully pushed repo '${repo.id}' to Protocol Land`, {


### PR DESCRIPTION
## Summary

This PR adds improvements by showing a push consent before pushing with fees. It also adds the ability to set the threshold cost above which the consent (y/n) is shown for push.

## How to test
1) Install dependencies, build and install remote helper
```bash
pnpm install && pnpm build && npm install -g .
```
2) Run PL locally with contract id as `xw8kD7s33ElIEioN96sPmLTJj9Rs2v4dZ67KWWKqojQ` and create a repo or use already created repo there.
3) Clone the repo, make some changes and push the changes. See info about on how to set threshold cost [here](https://github.com/labscommunity/protocol-land-remote-helper/tree/feat/push-tx-fee-consent?tab=readme-ov-file#setup-threshold-cost-for-push-consent)