### PR TITLE
fix: Fetch turbo free uploads limit & send repoId over Github sync trigger

### DIFF
--- a/.changeset/kind-goats-promise.md
+++ b/.changeset/kind-goats-promise.md
@@ -5,3 +5,4 @@
 -   fix: Fetch turbo free upload limit & send repo id over github sync api call #25
 -   feat: Clone repo using username/repoName or repo id #26
 -   perf: Improve warp caching #27
+-   feat: support tx subsidization #28

--- a/.changeset/kind-goats-promise.md
+++ b/.changeset/kind-goats-promise.md
@@ -1,0 +1,7 @@
+---
+'@protocol.land/git-remote-helper': minor
+---
+
+-   fix: Fetch turbo free upload limit & send repo id over github sync api call #25
+-   feat: Clone repo using username/repoName or repo id #26
+-   perf: Improve warp caching #27

--- a/.changeset/little-cheetahs-perform.md
+++ b/.changeset/little-cheetahs-perform.md
@@ -1,5 +1,0 @@
----
-'@protocol.land/git-remote-helper': patch
----
-
-Fetch turbo free upload limit & send repo id over github sync api call

--- a/.changeset/little-cheetahs-perform.md
+++ b/.changeset/little-cheetahs-perform.md
@@ -1,0 +1,5 @@
+---
+'@protocol.land/git-remote-helper': patch
+---
+
+Fetch turbo free upload limit & send repo id over github sync api call

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This command sets the global threshold cost for push consent to `0.0003 AR`. Whe
 
 Here's how it decides when to ask for your consent before uploading:
 
-- **No Set Threshold**: Without the threshold set, you'll only be asked for consent if the upload size exceeds the free subsidy size (For example: Turbo bundler used here allows upto 500KB uploads for free).
+- **No Set Threshold**: Without the threshold set, you'll only be asked for consent if the upload size exceeds the free subsidy size (For example: Turbo bundler used here allows upto 105KB uploads for free).
 - **Over the Threshold**: If the upload cost is more than the threshold, consent is requested only if the upload size is larger than what's freely allowed.
 - **Under the Threshold**: For costs below the threshold, consent isn't needed, and uploads proceed automatically.
 

--- a/src/lib/arweaveHelper.ts
+++ b/src/lib/arweaveHelper.ts
@@ -114,7 +114,12 @@ async function getTurboSubsidy() {
         const data = (await response.json()) as {
             freeUploadLimitBytes: number;
         };
-        return +data.freeUploadLimitBytes ?? defaultSubsidy;
+
+        const freeUploadLimitBytes = +data.freeUploadLimitBytes;
+
+        if (Number.isFinite(freeUploadLimitBytes)) return freeUploadLimitBytes;
+
+        return defaultSubsidy;
     } catch (err) {}
     return defaultSubsidy;
 }

--- a/src/lib/arweaveHelper.ts
+++ b/src/lib/arweaveHelper.ts
@@ -105,6 +105,20 @@ const shouldPushChanges = async (
     }
 };
 
+async function getTurboSubsidy() {
+    const defaultSubsidy = 107520;
+    try {
+        const response = await fetch('https://turbo.ardrive.io/');
+        if (!response.ok) return defaultSubsidy;
+
+        const data = (await response.json()) as {
+            freeUploadLimitBytes: number;
+        };
+        return +data.freeUploadLimitBytes ?? defaultSubsidy;
+    } catch (err) {}
+    return defaultSubsidy;
+}
+
 export async function uploadRepo(
     zipBuffer: Buffer,
     tags: Tag[],
@@ -127,8 +141,9 @@ export async function uploadRepo(
         //continue
     }
 
-    // 500KB subsidySize for TurboUpload and 0 subsidySize for ArweaveUpload
-    const subsidySize = Math.max(500 * 1024, 0);
+    // 105KB subsidySize for TurboUpload and 0 subsidySize for ArweaveUpload
+    const turboSubsidySize = await getTurboSubsidy();
+    const subsidySize = Math.max(turboSubsidySize, 0);
     const pushChanges = await shouldPushChanges(
         uploadSize,
         uploadCost,

--- a/src/lib/githubSync.ts
+++ b/src/lib/githubSync.ts
@@ -92,7 +92,10 @@ export async function triggerGithubSync(repo: Repo) {
                     'X-GitHub-Api-Version': '2022-11-28',
                     Authorization: `Bearer ${accessToken}`,
                 },
-                body: JSON.stringify({ ref: githubSync?.branch, inputs: {} }),
+                body: JSON.stringify({
+                    ref: githubSync?.branch,
+                    inputs: { repoId: repo.id },
+                }),
             }
         );
 


### PR DESCRIPTION
## Summary

This PR introduces fixes that address the turbo free uploads limit by automatically fetching the free uploads limit. Additionally, it streamlines the GitHub Sync trigger process by including the `repoId` in the inputs.

Related:
https://github.com/labscommunity/protocol-land/pull/96
https://github.com/labscommunity/protocol-land-sync-github/pull/6