### PR TITLE
feat: Clone repo using username/repoName or repo id

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This command enables `git` to synchronize with [Protocol Land](https://protocol.
 
 ### Clone Repositories
 
-Clone a repository using the following command:
+#### Clone a repository using ID
 
 ```bash
 git clone proland://YOUR_PROTOCOL_LAND_REPO_ID repo-name
@@ -87,6 +87,18 @@ For example, to clone [Protocol Land's repository](https://protocol.land/#/repos
 
 ```bash
 git clone proland://6ace6247-d267-463d-b5bd-7e50d98c3693 protocol-land
+```
+
+#### Clone a repository using username and repository name
+
+```bash
+git clone proland://username/repo-name
+```
+
+For example, to clone [Protocol Land's repository](https://protocol.land/#/repository/6ace6247-d267-463d-b5bd-7e50d98c3693), run:
+
+```bash
+git clone proland://clabstest/protocol-land
 ```
 
 ### Adding a Protocol Land Repository as a Remote

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -199,3 +199,25 @@ export const exitWithError = (message: string) => {
     log(``);
     process.exit(1);
 };
+
+export function isValidUuid(uuid: string) {
+    const REGEX =
+        /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
+    return typeof uuid === 'string' && REGEX.test(uuid);
+}
+
+export function setGitRemoteOrigin(repo: Repo) {
+    try {
+        const remoteUrl = process.argv[3];
+        if (!remoteUrl) return;
+
+        const repoId = `${remoteUrl.replace(/.*:\/\//, '')}`;
+        if (isValidUuid(repoId)) return;
+
+        const repoPath = gitdir.split(path.sep).slice(0, -2).join(path.sep);
+        const currentDir = process.cwd();
+        process.chdir(repoPath);
+        execSync(`git remote set-url origin proland://${repo.id}`);
+        process.chdir(currentDir);
+    } catch (error) {}
+}

--- a/src/lib/remoteHelper.ts
+++ b/src/lib/remoteHelper.ts
@@ -17,6 +17,7 @@ import {
     setCacheDirty,
     unsetCacheDirty,
     waitFor,
+    setGitRemoteOrigin,
 } from './common';
 import {
     trackRepositoryCloneEvent,
@@ -253,6 +254,7 @@ const spawnPipedGitCommand = async (
                 process.exit(1);
             }
         } else if (isCloningRepo) {
+            setGitRemoteOrigin(repo);
             await trackRepositoryCloneEvent(wallet, {
                 repo_name: repo.name,
                 repo_id: repo.id,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,16 @@
+export type User = {
+    fullname?: string;
+    username?: string;
+    isUserNameArNS?: boolean;
+    avatar?: string;
+    bio?: string;
+    location?: string;
+    twitter?: string;
+    email?: string;
+    website?: string;
+    readmeTxId?: string;
+};
+
 export type Repo = {
     id: string;
     name: string;


### PR DESCRIPTION
## Summary

This PR adds improvements to allow cloning repository using `repoId` or `username/repoName` format.

## How to test
1) Clone this repository and checkout `feat/clone-username-reponame` branch
2) Install dependencies, build & install package globally:
    ```sh
    pnpm install && pnpm build && npm install -g .
    ```
3) Clone the same repo using `repoId` and `username/repoName` format.

    ```sh
    git clone proland://pawanpaudel93/m3u-parser
    ```
    
    ```sh
    git clone proland://ae7b791d-7a1d-4a08-b08a-fc65ddcf4d4f m3u-parser-copy
    ```
## Related PR
https://github.com/labscommunity/protocol-land/pull/97