### PR TITLE
perf: Improve warp caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,11 @@ git remote add origin proland://YOUR_PROTOCOL_LAND_REPO_ID
 ```
 
 Replace `YOUR_PROTOCOL_LAND_REPO_ID` with the specific ID of the Protocol Land repository you wish to associate with your project. This establishes a connection to the remote repository, allowing you to fetch, pull, and push changes seamlessly.
+
+## Fix Remote Helper Issues
+
+If you're facing problems with the remote helper that is related to corrupted warp cache, try deleting the Warp cache directory shown while running Git commands. After deleting it, run your Git commands again to check if the issues are resolved.
+
+For example, this is the directory where the warp cache is stored. It varies for every user.
+
+![image](https://github.com/labscommunity/protocol-land-remote-helper/assets/11836100/640669bf-f196-4302-a5c2-3d1a95387b90)

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "@amplitude/analytics-node": "^1.3.4",
         "arbundles": "^0.10.0",
         "arweave": "^1.14.4",
+        "env-paths": "^3.0.0",
         "jszip": "^3.10.1",
         "node-machine-id": "^1.1.12",
         "redstone-api": "^0.4.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   arweave:
     specifier: ^1.14.4
     version: 1.14.4
+  env-paths:
+    specifier: ^3.0.0
+    version: 3.0.0
   jszip:
     specifier: ^3.10.1
     version: 3.10.1
@@ -1749,6 +1752,11 @@ packages:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
     dev: true
+
+  /env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
 
   /error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}

--- a/src/lib/protocolLandSync.ts
+++ b/src/lib/protocolLandSync.ts
@@ -25,7 +25,7 @@ export const downloadProtocolLandRepo = async (
     // find repo in Protocol Land's warp contract
     let repo: Repo | undefined;
     try {
-        repo = await getRepo(repoId, destPath);
+        repo = await getRepo(repoId);
     } catch (err) {
         log(err);
     }
@@ -52,7 +52,7 @@ export const downloadProtocolLandRepo = async (
         }
 
         // cache is dirty, clear cache and continue
-        clearCache(destPath, { keepFolders: ['cache'] });
+        clearCache(destPath, { keepFolders: [] });
     }
 
     // if not, download repo data from arweave
@@ -119,7 +119,7 @@ export const downloadProtocolLandRepo = async (
 
     // rm -rf everything but the bare repo and warp cache (discard stdout)
     try {
-        clearCache(destPath, { keepFolders: ['cache', repo.dataTxId] });
+        clearCache(destPath, { keepFolders: [repo.dataTxId] });
     } catch {}
 
     return repo;
@@ -176,7 +176,7 @@ export const uploadProtocolLandRepo = async (
 
     // update repo info in warp
     log('Updating in warp ...');
-    const updated = await updateWarpRepo(repo, dataTxId, destPath);
+    const updated = await updateWarpRepo(repo, dataTxId);
 
     // check for warp update success
     return { success: updated.id === repo.id, pushCancelled };

--- a/src/lib/remoteHelper.ts
+++ b/src/lib/remoteHelper.ts
@@ -209,7 +209,7 @@ const spawnPipedGitCommand = async (
             // We clear the cached remote:
             //   If upload succeeded, there's a new txId for the repo
             //   If upload failed, the cached remote has an inconsistent state
-            clearCache(tmpPath, { keepFolders: ['cache'] });
+            clearCache(tmpPath, { keepFolders: [] });
 
             // remove inconsistent cache mark
             unsetCacheDirty(tmpPath, repo.dataTxId);

--- a/src/lib/warpHelper.ts
+++ b/src/lib/warpHelper.ts
@@ -9,6 +9,7 @@ import {
     getWallet,
     getWarpContractTxId,
     isValidUuid,
+    log,
     waitFor,
 } from './common';
 import type { Repo, User } from '../types';
@@ -20,6 +21,8 @@ async function getWarpContract(signer?: any) {
     const contractTxId = getWarpContractTxId();
     const cacheDirectory = envPaths(PL_TMP_PATH, { suffix: '' }).cache;
     const cacheDirectoryExists = fs.existsSync(cacheDirectory);
+
+    log(`Warp cache stored at: ${cacheDirectory}`);
 
     const warp = getWarp(cacheDirectory);
     const contract = warp.contract(contractTxId);

--- a/src/lib/warpHelper.ts
+++ b/src/lib/warpHelper.ts
@@ -30,7 +30,9 @@ async function getWarpContract(signer?: any) {
     if (!cacheDirectoryExists) {
         fs.mkdirSync(cacheDirectory, { recursive: true });
         await contract
-            .syncState('https://dre-1.warp.cc/contract', { validity: true })
+            .syncState('https://pl-cache.saikranthi.dev/contract', {
+                validity: true,
+            })
             .catch(() => {});
     }
 
@@ -54,7 +56,7 @@ const getWarp = (destPath?: string, logLevel?: LogLevel) => {
 };
 
 export async function getRepo(id: string, destpath?: string) {
-    let pl = getWarp(destpath).contract(getWarpContractTxId());
+    let pl = await getWarpContract();
     if (isValidUuid(id)) {
         // let warp throw error if it can't retrieve the repository
         const response = await pl.viewState({


### PR DESCRIPTION
## Summary

This PR adds improvements by storing warp cache at a single location so that remote helper doesn't need to download cache per repo. Also, a DRE node is used to sync the state for the first time if cache is absent so it is faster.

## How to Test
1) Clone this repository and checkout `perf/improve-warp-caching` branch
2) Install dependencies, build & install package globally:
    ```sh
    pnpm install && pnpm build && npm install -g .
    ```
3) Clone a repo to see that it's faster now.  
    
    ```sh
    git clone proland://ae7b791d-7a1d-4a08-b08a-fc65ddcf4d4f m3u-parser
    ```