### PR TITLE
feat: support tx subsidization

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -47,3 +47,9 @@ export type Tag = {
     name: string;
     value: string;
 };
+
+export type SubsidizedUploadJsonResponse = {
+    success: boolean;
+    data: { repoTxId: string };
+    error?: string;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export type Tag = {
 
 export type SubsidizedUploadJsonResponse = {
     success: boolean;
+    bundled:boolean;
     data: { repoTxId: string };
     error?: string;
 };


### PR DESCRIPTION
## Summary
This PR prioritizes PL subsidizing node to post the tx. If failed, it asks user if they are interested to continue posting the tx with their wallet balance. If yes, default turbo/arweave upload flow continues. If no, we terminate the tx upload sequence.


![Screenshot 2024-03-11 at 4 54 07 AM](https://github.com/labscommunity/protocol-land-remote-helper/assets/57343520/c63e0d5a-3264-4f57-9fea-2143720fe946)

![Screenshot 2024-03-11 at 4 54 19 AM](https://github.com/labscommunity/protocol-land-remote-helper/assets/57343520/8ce7b05a-5513-42c1-bbf9-bcc582f18f6c)