### PR TITLE
fix: Make crypto key check work in different node versions

### DIFF
--- a/src/lib/privateRepo.ts
+++ b/src/lib/privateRepo.ts
@@ -5,6 +5,15 @@ import { getWallet, initArweave } from './common';
 
 const arweave = initArweave();
 
+function isCryptoKey(obj: any) {
+    try {
+        // @ts-ignore
+        return obj instanceof CryptoKey;
+    } catch (e) {
+        return obj instanceof crypto.webcrypto.CryptoKey;
+    }
+}
+
 async function deriveAddress(publicKey: string) {
     const pubKeyBuf = arweave.utils.b64UrlToBuffer(publicKey);
     const sha512DigestBuf = await crypto.subtle.digest('SHA-512', pubKeyBuf);
@@ -19,7 +28,7 @@ async function encryptDataWithExistingKey(
 ) {
     let key = aesKey;
 
-    if (!(aesKey instanceof crypto.webcrypto.CryptoKey)) {
+    if (!isCryptoKey(aesKey)) {
         key = await crypto.subtle.importKey(
             'raw',
             aesKey,


### PR DESCRIPTION
## Summary

This PR makes `aesKey instanceof crypto.webcrypto.CryptoKey` work on different node versions. For example, `crypto.webcrypto.CryptoKey` is `undefined` on node v20+.

> [!Note]
> - I am just fixing the instanceof issue on node v20+.
> - But we could also remove the `isCryptoKey` as `aesKey` is an ArrayBuffer so `isCryptoKey(aesKey)` is always `false`.

## How To Test
- **[Without Fix]** Run this in different node versions. (For eg: You could test in node 18 (**Success**) and 20 (**Fails**))
```ts
import crypto from 'crypto';

function isCryptoKey(obj) {
    return obj instanceof crypto.webcrypto.CryptoKey;
}

async function generateKey() {
    return await crypto.webcrypto.subtle.generateKey(
        {
            name: 'AES-GCM',
            length: 256,
        },
        true,
        ['encrypt', 'decrypt']
    );
}

async function checkIfCryptoKey() {
    const key = await generateKey();
    console.log(isCryptoKey(key));
}

checkIfCryptoKey().catch(console.error);
```

- **[With Fix]** Run this in different node versions. (For eg: You could test in node 18 (**Success**) and 20 (**Success**))
```ts
import crypto from 'crypto';

function isCryptoKey(obj) {
    try {
        return obj instanceof CryptoKey;
    } catch (e) {
        return obj instanceof crypto.webcrypto.CryptoKey;
    }
}

async function generateKey() {
    return await crypto.webcrypto.subtle.generateKey(
        {
            name: 'AES-GCM',
            length: 256,
        },
        true,
        ['encrypt', 'decrypt']
    );
}

async function checkIfCryptoKey() {
    const key = await generateKey();
    console.log(isCryptoKey(key));
}

checkIfCryptoKey().catch(console.error);
```